### PR TITLE
chore: bump jsonwebtoken to version from 8 to 9

### DIFF
--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,7 +32,7 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.22"
-jsonwebtoken = "9"
+jsonwebtoken = { git = "https://git.pfaff.dev/michael/jsonwebtoken" }
 
 async-trait.workspace = true
 hex.workspace = true

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,7 +32,7 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.22"
-jsonwebtoken = "8"
+jsonwebtoken = "9"
 
 async-trait.workspace = true
 hex.workspace = true


### PR DESCRIPTION
It uses the latest Ring, which fixes an issue for compiling to wasm32-wasi

Issue: https://github.com/briansmith/ring/issues/1043

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
